### PR TITLE
Make for loop for arch run properly

### DIFF
--- a/model-packaging/build-trigger-function/index.js
+++ b/model-packaging/build-trigger-function/index.js
@@ -67,7 +67,7 @@ exports.modelDoneWatcher = function (event, callback) {
           auth: authClient
         });
 
-        for (var i = 0; i <= arrayLength; i++) {
+        for (var i = 0; i < arrayLength; i++) {
           arch = archs[i];
           console.log('Submitting build for ' + arch);
           job = undefined;


### PR DESCRIPTION
Fixed: For loop ran for another undefined arch, which caused bogus container build job